### PR TITLE
Ensure a gem-named require file exists

### DIFF
--- a/lib/rbvmomi2.rb
+++ b/lib/rbvmomi2.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative './rbvmomi'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@
 require 'simplecov'
 SimpleCov.start { add_filter '/test/' }
 
-require 'rbvmomi'
+require 'rbvmomi2'
 VIM = RbVmomi::VIM
 
 require 'test/unit'


### PR DESCRIPTION
@agrare Please review.  If a user does `gem "rbvmomi2"`, then by default bundler will look for this specific file to require.