### PR TITLE
Add a way to auto-generate the CONTRIBUTORS list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,9 @@
+* Adam Grare <adam@grare.com>
 * Adam Grare <agrare@redhat.com>
 * Anurag Uniyal <auniyal@vmware.com>
 * Atul Bhosale <atul1bhosale@gmail.com>
 * Benjamin Bytheway <ben.bytheway@imail.org>
+* Chao Li <li.evan.chao@gmail.com>
 * Christian Dickmann <cdickmann@ubuntu.(none)>
 * Christian Dickmann <cdickmann@vmware.com>
 * Colin O'Byrne and Martin Marinov <cobyrne@vmware.com>
@@ -19,17 +21,22 @@
 * Guido Günther <agx@sigxcpu.org>
 * Hari Krishnamurthy <hkrishna@vmware.com>
 * J.R. Garcia <jr@garciaole.com>
+* J.R. Garcia <jrg@vmware.com>
 * Jacob Evans <jacob@dekz.net>
 * Jason Frey <fryguy9@gmail.com>
+* JavaScriptDude <tim.c.quinn@gmail.com>
+* Jeremy <Jeremy@Macintosh.local>
 * Justin <justin@labs.epiuse.com>
+* Kent 'picat' Gruber <kgruber1@emich.edu>
 * Kevin Menard <nirvdrum@gmail.com>
 * Lalitha Sripada <lsripada@vmware.com>
 * Martin Englund <martin@englund.nu>
+* Martin Mosegaard Amdisen <martin.amdisen@praqma.com>
 * Nan Liu <nan.liu@gmail.com>
-* Omar Baba <obaba@infinio.com>
 * Peter <peter.adkins@kernelpicnic.net>
 * Puneet Katyal <pkatyal@vmware.com>
 * Randy Robertson <rmrobert@vmware.com>
+* Raul <rmahique-github@raulmahiques.com>
 * Rich Lane <lanerl@gmail.com>
 * Rich Lane <rlane@club.cc.cmu.edu>
 * Rich Lane <rlane@vmware.com>
@@ -41,11 +48,13 @@
 * Soner Sevinc <sevincs@vmware.com>
 * Tae <tae8838@users.noreply.github.com>
 * Tim Smith <tsmith84@gmail.com>
+* Tim Smith <tsmith@chef.io>
 * Tom Bortels <bortels@gmail.com>
 * Tom Giordano <tomgiordano83@gmail.com>
 * Tu Hoang <rebyn@me.com>
 * administrator <administrator@cdickmann-mbpro.gateway.2wire.net>
 * cdickmann <christian.dickmann@gmail.com>
+* dstefka <46713793+dstefka@users.noreply.github.com>
 * howels <howels@users.noreply.github.com>
 * kumabuchi.kenji <k.kumabuchi+github@gmail.com>
 * thanhngn <thanhngn@users.noreply.github.com>

--- a/Rakefile
+++ b/Rakefile
@@ -19,3 +19,11 @@ end
 RuboCop::RakeTask.new
 
 YARD::Rake::YardocTask.new
+
+desc 'Update the CONTRIBUTORS.md'
+task :update_contributors do
+  contributors = `git log --format='%aN <%aE>'`.each_line.map(&:chomp).sort.uniq
+  contributors.reject! { |c| c.start_with?('dependabot[bot]') }
+  content = contributors.map { |c| "* #{c}" }.join("\n") << "\n"
+  File.write(File.expand_path('CONTRIBUTORS.md', __dir__), content)
+end


### PR DESCRIPTION
@agrare Please review.

Alternatively, maybe we can just drop the CONTRIBUTORS.md.  I like giving proper contribution, but this list is trivial for anyone to generate (`git shortlog -nes` being probably the simplest example), and it just incurs overhead on maintenance.