### PR TITLE
Add a logger to RbVmomi in place of `$stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add a configurable RbVmomi.logger (#14)
 
 ## [3.2.0] - 2021-10-08
 ### Added

--- a/lib/rbvmomi.rb
+++ b/lib/rbvmomi.rb
@@ -12,6 +12,7 @@ module RbVmomi
 end
 
 require_relative 'rbvmomi/connection'
+require_relative 'rbvmomi/logging'
 require_relative 'rbvmomi/sso'
 require_relative 'rbvmomi/version'
 require_relative 'rbvmomi/vim'

--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -195,7 +195,7 @@ module RbVmomi
       end
       xml
     rescue
-      RbVmomi.logger.error("#{$!.class} while serializing #{name} (#{type}): #{o}")
+      RbVmomi.logger.error("#{$!.class} while serializing #{name} (#{type}): #{o.pretty_inspect}")
       raise
     end
 

--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -195,7 +195,7 @@ module RbVmomi
       end
       xml
     rescue
-      RbVmomi.logger.error("#{$!.class} while serializing #{name} (#{type}): #{o.pretty_inspect}")
+      RbVmomi.logger.error("#{$!.class} while serializing #{name} (#{type})\n#{o.pretty_inspect}")
       raise
     end
 

--- a/lib/rbvmomi/connection.rb
+++ b/lib/rbvmomi/connection.rb
@@ -195,8 +195,7 @@ module RbVmomi
       end
       xml
     rescue
-      $stderr.puts "#{$!.class} while serializing #{name} (#{type}):"
-      PP.pp o, $stderr
+      RbVmomi.logger.error("#{$!.class} while serializing #{name} (#{type}): #{o}")
       raise
     end
 

--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -221,8 +221,7 @@ module RbVmomi
       else raise "unexpected type #{t.inspect} (#{t.ancestors * '/'})"
       end
     rescue
-      RbVmomi.logger.error("#{$!.class} while deserializing #{xml.name} (#{typename}):")
-      RbVmomi.logger.error(xml.to_s)
+      RbVmomi.logger.error("#{$!.class} while deserializing #{xml.name} (#{typename}):\n#{xml.to_s}")
       raise
     end
 

--- a/lib/rbvmomi/deserialization.rb
+++ b/lib/rbvmomi/deserialization.rb
@@ -221,8 +221,8 @@ module RbVmomi
       else raise "unexpected type #{t.inspect} (#{t.ancestors * '/'})"
       end
     rescue
-      $stderr.puts "#{$!.class} while deserializing #{xml.name} (#{typename}):"
-      $stderr.puts xml.to_s
+      RbVmomi.logger.error("#{$!.class} while deserializing #{xml.name} (#{typename}):")
+      RbVmomi.logger.error(xml.to_s)
       raise
     end
 

--- a/lib/rbvmomi/logging.rb
+++ b/lib/rbvmomi/logging.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RbVmomi
+  class << self
+    attr_writer :logger
+  end
+
+  def self.logger
+    require 'logger'
+    @logger ||= Logger.new(nil)
+  end
+
+  module Logging
+    def logger
+      RbVmomi.logger
+    end
+  end
+end

--- a/lib/rbvmomi/logging.rb
+++ b/lib/rbvmomi/logging.rb
@@ -6,7 +6,9 @@ module RbVmomi
   end
 
   def self.logger
-    require 'logger'
-    @logger ||= Logger.new($stderr)
+    @logger ||= begin
+      require 'logger'
+      Logger.new($stderr)
+    end
   end
 end

--- a/lib/rbvmomi/logging.rb
+++ b/lib/rbvmomi/logging.rb
@@ -7,7 +7,7 @@ module RbVmomi
 
   def self.logger
     require 'logger'
-    @logger ||= Logger.new(nil)
+    @logger ||= Logger.new($stderr)
   end
 
   module Logging

--- a/lib/rbvmomi/logging.rb
+++ b/lib/rbvmomi/logging.rb
@@ -9,10 +9,4 @@ module RbVmomi
     require 'logger'
     @logger ||= Logger.new($stderr)
   end
-
-  module Logging
-    def logger
-      RbVmomi.logger
-    end
-  end
 end

--- a/lib/rbvmomi/pbm.rb
+++ b/lib/rbvmomi/pbm.rb
@@ -18,7 +18,7 @@ module RbVmomi
     # @option opts [Boolean] :ssl (true) Whether to use SSL.
     # @option opts [Boolean] :insecure (false) If true, ignore SSL certificate errors.
     # @option opts [String]  :path (/pbm/sdk) SDK endpoint path.
-    # @option opts [Boolean] :debug (false) If true, print SOAP traffic to stderr.
+    # @option opts [Boolean] :debug (false) If true, print SOAP traffic to RbVmomi.logger.debug.
     def self.connect vim, opts = {}
       raise unless opts.is_a? Hash
 

--- a/lib/rbvmomi/sms.rb
+++ b/lib/rbvmomi/sms.rb
@@ -17,7 +17,7 @@ module RbVmomi
     # @option opts [Boolean] :ssl (true) Whether to use SSL.
     # @option opts [Boolean] :insecure (false) If true, ignore SSL certificate errors.
     # @option opts [String]  :path (/sms/sdk) SDK endpoint path.
-    # @option opts [Boolean] :debug (false) If true, print SOAP traffic to stderr.
+    # @option opts [Boolean] :debug (false) If true, print SOAP traffic to RbVmomi.logger.debug.
     def self.connect vim, opts = {}
       raise unless opts.is_a? Hash
 

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -85,9 +85,8 @@ class RbVmomi::TrivialSoap
     headers['cookie'] = @cookie if @cookie
 
     if @debug
-      $stderr.puts 'Request:'
-      $stderr.puts body
-      $stderr.puts
+      RbVmomi.logger.debug('Request:')
+      RbVmomi.logger.debug(body)
     end
 
     if @cookie.nil? && @sso
@@ -113,9 +112,8 @@ class RbVmomi::TrivialSoap
     nk = Nokogiri(response.body)
 
     if @debug
-      $stderr.puts "Response (in #{'%.3f' % (end_time - start_time)} s)"
-      $stderr.puts nk
-      $stderr.puts
+      RbVmomi.logger.debug("Response (in #{'%.3f' % (end_time - start_time)} s)")
+      RbVmomi.logger.debug(nk)
     end
 
     [nk.xpath('//soapenv:Body/*').select(&:element?).first, response.body.size]

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -84,10 +84,7 @@ class RbVmomi::TrivialSoap
     headers = { 'content-type' => 'text/xml; charset=utf-8', 'SOAPAction' => action }
     headers['cookie'] = @cookie if @cookie
 
-    if @debug
-      RbVmomi.logger.debug('Request:')
-      RbVmomi.logger.debug(body)
-    end
+    RbVmomi.logger.debug("Request:\n#{body}") if @debug
 
     if @cookie.nil? && @sso
       @sso.request_token unless @sso.assertion_id
@@ -111,10 +108,7 @@ class RbVmomi::TrivialSoap
 
     nk = Nokogiri(response.body)
 
-    if @debug
-      RbVmomi.logger.debug("Response (in #{'%.3f' % (end_time - start_time)} s)")
-      RbVmomi.logger.debug(nk)
-    end
+    RbVmomi.logger.debug("Response (in #{'%.3f' % (end_time - start_time)} s)\n#{nk}") if @debug
 
     [nk.xpath('//soapenv:Body/*').select(&:element?).first, response.body.size]
   end

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -18,7 +18,7 @@ module RbVmomi
     # @option opts [String]  :user (root) Username.
     # @option opts [String]  :password Password.
     # @option opts [String]  :path (/sdk) SDK endpoint path.
-    # @option opts [Boolean] :debug (false) If true, print SOAP traffic to stderr.
+    # @option opts [Boolean] :debug (false) If true, print SOAP traffic to RbVmomi.logger.debug.
     # @option opts [String]  :operation_id If set, use for operationID
     # @option opts [Boolean] :close_on_exit (true) If true, will close connection with at_exit
     # @option opts [RbVmomi::SSO] :sso (nil) Use SSO token to login if set
@@ -56,7 +56,7 @@ module RbVmomi
     def close
       serviceContent.sessionManager.Logout
     rescue RbVmomi::Fault => e
-      $stderr.puts(e.message) if debug
+      RbVmomi.logger.error(e.message) if debug
     ensure
       self.cookie = nil
       super


### PR DESCRIPTION
Currently `$stdout` is used to print errors and debug information, we should provide a user configurable logger so that log messages can be sent to the location of their choosing