### PR TITLE
Update the default latest vSphere version to 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Update the default latest supported vSphere version (#20)
 
 ## [3.4.1] - 2022-09-29
 ### Fixed

--- a/lib/rbvmomi/vim.rb
+++ b/lib/rbvmomi/vim.rb
@@ -34,7 +34,7 @@ module RbVmomi
       opts[:port] ||= (opts[:ssl] ? 443 : 80)
       opts[:path] ||= '/sdk'
       opts[:ns] ||= 'urn:vim25'
-      opts[:rev] = '6.7' if opts[:rev].nil?
+      opts[:rev] = '7.0' if opts[:rev].nil?
       opts[:debug] = (!ENV['RBVMOMI_DEBUG'].empty? rescue false) unless opts.member? :debug
 
       conn = new(opts).tap do |vim|


### PR DESCRIPTION
Update the default supported vSphere version to 7.0, later on in `.connect` we use the minimum of the default rev and the version reported by vSphere so if this wasn't provided it would default to 6.7 even if the vSphere was 7.0.