### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.version }}
           bundler-cache: true
+          bundler: 2.3.18
 
       - name: Run tests
         run: bundle exec rake


### PR DESCRIPTION
Lock down bundler to 2.3.18 to fix bundle install failing on CI with windows platforms

Bundler 2.3.23 causes an issue where nokogiri on Windows (x64-mingw-ucrt) doesn't install the mini_portile dependency, but bundler 2.3.18 seems to do the right thing.