### PR TITLE
Fix version diff links in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Improve #to_json behavior on RbVmomi Objects (#185)
 
 [Unreleased]: https://github.com/ManageIQ/rbvmomi2/compare/v3.5.0...HEAD
-[3.5.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.5.0...v3.4.0
-[3.4.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.4.0...v3.3.0
+[3.5.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.4.2...v3.5.0
+[3.4.2]: https://github.com/ManageIQ/rbvmomi2/compare/v3.4.1...v3.4.2
+[3.4.1]: https://github.com/ManageIQ/rbvmomi2/compare/v3.4.0...v3.4.1
+[3.4.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/ManageIQ/rbvmomi2/compare/v3.0.1...v3.1.0


### PR DESCRIPTION
Some of the links in the changelog were backwards comparing the old tag to the new tag yielding now changes.