### PR TITLE
[WIP] Replace to_hash with as_json

### DIFF
--- a/lib/rbvmomi/basic_types.rb
+++ b/lib/rbvmomi/basic_types.rb
@@ -23,6 +23,10 @@ module RbVmomi
         end
       end
 
+      def as_json
+        to_s
+      end
+
       init
     end
 
@@ -162,22 +166,24 @@ module RbVmomi
         q.text ')'
       end
 
-      def as_hash(val)
-        if val.kind_of?(Array)
-          val.map { |v| as_hash(v) }
-        elsif val.respond_to?(:to_hash)
-          val.to_hash
-        else
-          val
-        end
-      end
-
-      def to_hash
-        props.transform_values { |v| as_hash(v) }
+      def as_json
+        props.transform_values { |v| as_json_nested(v) }
       end
 
       def to_json(options = nil)
-        to_hash.merge(JSON.create_id => self.class.name).to_json
+        as_json.merge(JSON.create_id => self.class.name).to_json
+      end
+
+      private
+
+      def as_json_nested(val)
+        if val.kind_of?(Array)
+          val.map { |v| as_json_nested(v) }
+        elsif val.respond_to?(:as_json)
+          val.as_json
+        else
+          val
+        end
       end
 
       init
@@ -201,10 +207,6 @@ module RbVmomi
 
       def to_s
         "#{self.class.wsdl_name}(#{@ref.inspect})"
-      end
-
-      def to_hash
-        to_s
       end
 
       def pretty_print pp
@@ -282,7 +284,7 @@ module RbVmomi
         @value = value
       end
 
-      def to_hash
+      def to_s
         value
       end
 

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -25,30 +25,30 @@ class MiscTest < Test::Unit::TestCase
     assert_equal klass, klass2
   end
 
-  def test_managed_object_to_hash
-    assert_equal VIM.VirtualMachine(nil, 'vm-123').to_hash, 'VirtualMachine("vm-123")'
+  def test_managed_object_as_json
+    assert_equal VIM.VirtualMachine(nil, 'vm-123').as_json, 'VirtualMachine("vm-123")'
   end
 
   def test_managed_object_to_json
     assert_equal VIM.VirtualMachine(nil, 'vm-123').to_json, '"VirtualMachine(\\"vm-123\\")"'
   end
 
-  def test_data_object_to_hash
+  def test_data_object_as_json
     # With a nested ManagedObject value
-    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, 'vm-123')}).to_hash, {vm: 'VirtualMachine("vm-123")'}
+    assert_equal VIM.VirtualMachineSummary({vm: VIM.VirtualMachine(nil, 'vm-123')}).as_json, {vm: 'VirtualMachine("vm-123")'}
 
     # With an array
-    assert_equal VIM.VirtualMachineSummary({customValue: [VIM.CustomFieldValue({key: 1})]}).to_hash, {customValue: [{key: 1}]}
+    assert_equal VIM.VirtualMachineSummary({customValue: [VIM.CustomFieldValue({key: 1})]}).as_json, {customValue: [{key: 1}]}
 
     # With an Enum
-    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus('green')}).to_hash, {overallStatus: 'green'}
+    assert_equal VIM.VirtualMachineSummary({overallStatus: VIM.ManagedEntityStatus('green')}).as_json, {overallStatus: 'green'}
 
     # Combined
     assert_equal VIM.VirtualMachineSummary(
       vm: VIM.VirtualMachine(nil, 'vm-123'),
       customValue: [VIM.CustomFieldValue(key: 1)],
       overallStatus: VIM.ManagedEntityStatus('green')
-    ).to_hash,
+    ).as_json,
     {
       vm: 'VirtualMachine("vm-123")',
       customValue: [{key: 1}],


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/rbvmomi2/pull/29/files#r1062876312

@Fryguy I wonder if `#as_json` might be better since `String#as_json` returns a `String` just wanted to throw this up to start the coversation