### PR TITLE
Fix CHANGELOG.md PR links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,61 +6,61 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.6.1] - 2023-02-05
 ### Fixed
-- Fix unknown VMODL type ContentLibraryItem (#35)
+- Fix unknown VMODL type ContentLibraryItem ([#35](https://github.com/ManageIQ/rbvmomi2/pull/35))
 
 ### Added
-- Add ManageIQ/bundler-inject (#31)
+- Add ManageIQ/bundler-inject ([#31](https://github.com/ManageIQ/rbvmomi2/pull/31))
 
 ## [3.6.0] - 2023-02-05
 ### Fixed
-- Fix unknown VMODL type ContentLibrary (#29)
+- Fix unknown VMODL type ContentLibrary ([#29](https://github.com/ManageIQ/rbvmomi2/pull/29))
 
 ## [3.5.0] - 2022-11-09
 ### Added
-- Add vSphere 8.0 support (#21)
-- Add a manual option to run the Test github action on demand (#22)
-- Test with ruby 3.0 and 3.1 (#25)
+- Add vSphere 8.0 support ([#21](https://github.com/ManageIQ/rbvmomi2/pull/21))
+- Add a manual option to run the Test github action on demand ([#22](https://github.com/ManageIQ/rbvmomi2/pull/22))
+- Test with ruby 3.0 and 3.1 ([#25](https://github.com/ManageIQ/rbvmomi2/pull/25))
 
 ### Fixed
-- Bundler v2.3.24 resolves windows nokogiri issue (#26)
+- Bundler v2.3.24 resolves windows nokogiri issue ([#26](https://github.com/ManageIQ/rbvmomi2/pull/26))
 
 ## [3.4.2] - 2022-09-30
 ### Fixed
-- Update the default latest supported vSphere version (#20)
+- Update the default latest supported vSphere version ([#20](https://github.com/ManageIQ/rbvmomi2/pull/20))
 
 ## [3.4.1] - 2022-09-29
 ### Fixed
-- Fix new properties being cleared by SMS.wsdl (#19)
+- Fix new properties being cleared by SMS.wsdl ([#19](https://github.com/ManageIQ/rbvmomi2/pull/19))
 
 ## [3.4.0] - 2022-09-09
 ### Added
-- Add support for vSphere 7.0U3f
+- Add support for vSphere 7.0U3f ([#17](https://github.com/ManageIQ/rbvmomi2/pull/17))
 
 ### Fixed
-- Fix new properties not being added to existing objects (#16)
-- Fix new enums not being added (#17)
+- Fix new properties not being added to existing objects ([#16](https://github.com/ManageIQ/rbvmomi2/pull/16))
+- Fix new enums not being added ([#17](https://github.com/ManageIQ/rbvmomi2/pull/17))
 
 ## [3.3.0] - 2022-03-10
 ### Added
-- Add a configurable RbVmomi.logger (#14)
+- Add a configurable RbVmomi.logger ([#14](https://github.com/ManageIQ/rbvmomi2/pull/14))
 
 ## [3.2.0] - 2021-10-08
 ### Added
-- Add support for vSphere 7.0U3 (#7)
+- Add support for vSphere 7.0U3 ([#7](https://github.com/ManageIQ/rbvmomi2/pull/7))
 
 ## [3.1.0] - 2021-09-23
 ### Added
-- Add support for vSphere 7.0U2 (#4)
+- Add support for vSphere 7.0U2 ([#4](https://github.com/ManageIQ/rbvmomi2/pull/4))
 
 ## [3.0.1] - 2021-09-23
 ### Changed
-- Remove WIN32::SSPI (#187)
-- Remove WIN32::SSPI usage (#186)
-- Add a script to verify vmodl.db from a wsdl file (#177)
+- Remove WIN32::SSPI ([#187](https://github.com/vmware/rbvmomi/pull/187))
+- Remove WIN32::SSPI usage ([#186](https://github.com/vmware/rbvmomi/pull/186))
+- Add a script to verify vmodl.db from a wsdl file ([#177](https://github.com/vmware/rbvmomi/pull/177))
 
 ### Fixed
-- Fix unescaped characters in Datastore URLs (#183)
-- Improve #to_json behavior on RbVmomi Objects (#185)
+- Fix unescaped characters in Datastore URLs ([#183](https://github.com/vmware/rbvmomi/pull/183))
+- Improve #to_json behavior on RbVmomi Objects ([#185](https://github.com/vmware/rbvmomi/pull/185))
 
 [Unreleased]: https://github.com/ManageIQ/rbvmomi2/compare/v3.6.1...HEAD
 [3.6.1]: https://github.com/ManageIQ/rbvmomi2/compare/v3.6.0...v3.6.1


### PR DESCRIPTION
The original format from `vmware/rbvmomi` was `(#PR)` without a link but we should improve this to make it simpler for users to access links from the changelog.