### PR TITLE
Add Ruby 3.3 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         - "3.0"
         - "3.1"
         - "3.2"
+        - "3.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/rbvmomi2.gemspec
+++ b/rbvmomi2.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rake', '~> 13.0')
   spec.add_development_dependency('rubocop', '~> 1.0', '>= 1.29.0')
   spec.add_development_dependency('simplecov', '~> 0.19.0')
-  spec.add_development_dependency('soap4r-ng', '~> 2.0')
+  spec.add_development_dependency('soap4r-ng', '~> 2.0', '>= 2.0.6')
   spec.add_development_dependency('test-unit', '~> 3.3')
   spec.add_development_dependency('yard', '~> 0.9.36')
 


### PR DESCRIPTION
3.3 is actually broken with the following error:

```
rake aborted!
ArgumentError: wrong number of arguments (given 3, expected 1..2) (ArgumentError)

  USASCIIRegexp = Regexp.new("\\A#{us_ascii}*\\z", nil, 'n')
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/jfrey/.gem/ruby/3.3.0/gems/soap4r-ng-2.0.4/lib/xsd/charset.rb:133:in `initialize'
/Users/jfrey/.gem/ruby/3.3.0/gems/soap4r-ng-2.0.4/lib/xsd/charset.rb:133:in `new'
/Users/jfrey/.gem/ruby/3.3.0/gems/soap4r-ng-2.0.4/lib/xsd/charset.rb:133:in `<module:Charset>'
/Users/jfrey/.gem/ruby/3.3.0/gems/soap4r-ng-2.0.4/lib/xsd/charset.rb:13:in `<module:XSD>'
/Users/jfrey/.gem/ruby/3.3.0/gems/soap4r-ng-2.0.4/lib/xsd/charset.rb:10:in `<top (required)>'
/Users/jfrey/.gem/ruby/3.3.0/gems/soap4r-ng-2.0.4/lib/wsdl/parser.rb:11:in `<top (required)>'
/Users/jfrey/dev/rbvmomi2/lib/tasks/vmodl_helper.rb:6:in `<top (required)>'
lib/tasks/vmodl.rake:3:in `require_relative'
lib/tasks/vmodl.rake:3:in `<top (required)>'
/Users/jfrey/dev/rbvmomi2/Rakefile:10:in `load'
/Users/jfrey/dev/rbvmomi2/Rakefile:10:in `block in <top (required)>'
/Users/jfrey/dev/rbvmomi2/Rakefile:10:in `each'
/Users/jfrey/dev/rbvmomi2/Rakefile:10:in `<top (required)>'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/cli/exec.rb:58:in `load'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/cli/exec.rb:58:in `kernel_load'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/cli/exec.rb:23:in `run'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/cli.rb:451:in `exec'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/cli.rb:34:in `dispatch'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/cli.rb:28:in `start'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/exe/bundle:28:in `block in <top (required)>'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/Users/jfrey/.gem/ruby/3.3.0/gems/bundler-2.5.5/exe/bundle:20:in `<top (required)>'
/Users/jfrey/.rubies/ruby-3.3.0/bin/bundle:25:in `load'
/Users/jfrey/.rubies/ruby-3.3.0/bin/bundle:25:in `<main>'
(See full trace by running task with --trace)
```

---

From what I can see, soap4r-ng is the problem, however, strangely, I have no idea what it's intention was.  See https://github.com/rubyjedi/soap4r/blob/master/lib/xsd/charset.rb#L133.  (Aside, note that the README says the gem is unmaintained ☹️).

Looking at the blame it was
- Changed to `'n'` for Ruby 1.9 compat: https://github.com/rubyjedi/soap4r/commit/72d438cc5341a78bb7c3b131b6f8f9b0a0a012f2
- `'NONE'` since the first commit _21 years ago_: https://github.com/rubyjedi/soap4r/commit/d15647f9cec7546a9908b4b0b9363f871fcad207

---

The interface for Regexp is the following for Ruby [3.2.3](https://ruby-doc.org/3.2.3/Regexp.html#method-c-new) and [3.3.0](https://ruby-doc.org/3.3.0/Regexp.html#method-c-new):

```
new(string, options = 0, timeout: nil) → regexp
new(regexp, timeout: nil) → regexp 
```

and is the following for Ruby [3.1.4](https://ruby-doc.org/3.1.4/Regexp.html#method-c-new), [3.0.6](https://ruby-doc.org/3.0.6/Regexp.html#method-c-new), [2.7.8](https://ruby-doc.org/2.7.8/Regexp.html#method-c-new), [2.6.10](https://ruby-doc.org/core-2.6.10/Regexp.html#method-c-new), and [2.5.9](https://ruby-doc.org/core-2.5.9/Regexp.html#method-c-new)

```
new(string, [options]) → regexp
new(regexp) → regexp
```

The code in question is

```ruby
USASCIIRegexp = Regexp.new("\\A#{us_ascii}*\\z", nil, 'n')
```

so I have no idea what that 3rd parameter is supposed to be (I assume some older Ruby thing, but I'm having trouble finding docs)