### PR TITLE
Fix Ruby 2.5 tests on macos by pinning to macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
         - "3.0"
         - "3.1"
         - "3.2"
+        exclude:
+        - os: macos-latest
+          version: "2.5"
+        include:
+        - os: macos-13
+          version: "2.5"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
macos-latest is macos-14-arm64, but Ruby 2.5 can't be built on that version. Instead we can use macos-13.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
