### PR TITLE
Bump rubocop to handle some CVEs and drop Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         version:
-        - "2.5"
         - "2.6"
         - "2.7"
         - "3.0"
         - "3.1"
         - "3.2"
-        exclude:
-        - os: macos-latest
-          version: "2.5"
-        include:
-        - os: macos-13
-          version: "2.5"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/rbvmomi2.gemspec
+++ b/rbvmomi2.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('activesupport')
   spec.add_development_dependency('pry', '~> 0.14.1')
   spec.add_development_dependency('rake', '~> 13.0')
-  spec.add_development_dependency('rubocop', '~> 1.0')
+  spec.add_development_dependency('rubocop', '~> 1.0', '>= 1.29.0')
   spec.add_development_dependency('simplecov', '~> 0.19.0')
   spec.add_development_dependency('soap4r-ng', '~> 2.0')
   spec.add_development_dependency('test-unit', '~> 3.3')


### PR DESCRIPTION
rubocop 1.29.0 requires dropping Ruby 2.5, so this PR also drops Ruby 2.5 support.

Attempting to `Fix #57`