### PR TITLE
Add a rake task to output vmodl YAML file

### DIFF
--- a/lib/tasks/vmodl.rake
+++ b/lib/tasks/vmodl.rake
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative './vmodl_helper'
+require 'yaml'
+require 'pathname'
 
 namespace :vmodl do
   desc 'Verify vmodl.db'
@@ -11,5 +13,16 @@ namespace :vmodl do
   desc 'Generate vmodl.db'
   task :generate do
     VmodlHelper.generate!
+  end
+
+  desc 'Convert vmodl.db to vmodl.yml'
+  task :to_yaml do
+    gem_root = Pathname.new(__dir__).join('../..')
+    db_path  = gem_root.join('vmodl.db')
+    yml_path = gem_root.join('vmodl.yml')
+
+    vmodl_data = Marshal.load(File.binread(db_path))
+
+    File.write(yml_path, YAML.dump(vmodl_data))
   end
 end


### PR DESCRIPTION
When updating the vmodl.db marshal dump it is helpful to output a YAML representation for an easier comparison/diff that isn't possible with the binary representation.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
