### PR TITLE
Add `:cert_store` and `:ca_cert` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Add `:cert_store` and `:ca_cert` options to `RbVmomi::TrivialSoap`
+
 ## [3.9.0] - 2026-04-10
 ### Added
 - Add VCF 9.0 support ([#82](https://github.com/ManageIQ/rbvmomi2/pull/82))

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ A few important points:
 *   If you don't have trusted SSL certificates installed on the host you're
     connecting to, you'll get an `OpenSSL::SSL::SSLError` "certificate verify
     failed". You can work around this by using the `:insecure` option to
-    `RbVmomi::VIM.connect`.
+    `RbVmomi::VIM.connect` or by passing the certificate authority with the `:ca_file`,
+    `:ca_cert`, or `:cert_store` options.
 *   This is a side project of a VMware employee and is entirely unsupported by
     VMware.
 

--- a/lib/rbvmomi/trivial_soap.rb
+++ b/lib/rbvmomi/trivial_soap.rb
@@ -48,6 +48,11 @@ class RbVmomi::TrivialSoap
       @http.use_ssl = true
       @http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @opts[:insecure]
       @http.ca_file = @opts[:ca_file] if @opts[:ca_file]
+      if @opts[:cert_store]
+        @http.cert_store = @opts[:cert_store]
+      elsif @opts[:ca_cert]
+        @http.cert_store = OpenSSL::X509::Store.new.add_cert(OpenSSL::X509::Certificate.new(@opts[:ca_cert]))
+      end
       @http.cert = OpenSSL::X509::Certificate.new(@opts[:cert]) if @opts[:cert]
       @http.key = OpenSSL::PKey::RSA.new(@opts[:key]) if @opts[:key]
     end


### PR DESCRIPTION
`TrivialSoap` passes specific options to `Net::HTTP` so in order to support a certificate authority string or `OpenSSL::X509::Store` we have to handle that specifically.

This allows the user to pass the certificate authority as a string, or an entire `OpenSSL::X509::Store` object which might include multiple certificates.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
